### PR TITLE
Changed old title of BioRXiv Comparison viewer paper with the new 

### DIFF
--- a/_includes/main.html
+++ b/_includes/main.html
@@ -294,7 +294,7 @@
         Users should adhere to the Allen Institutes <a href="https://alleninstitute.org/legal/terms-use/" target="_blank">data terms of use</a> and <a href="https://alleninstitute.org/legal/citation-policy/" target="_blank">citation policy</a>.
         If you use Cytosplore Viewer within the scope of a scientific article you must cite the original publications:
 				<br/>
-				Bakken et al. <span class="middle-blue">Evolution of cellular diversity in primary motor cortex of human, marmoset monkey, and mouse</span>, <em>bioRXiv,</em> 2020.
+				Bakken et al. <span class="middle-blue">Comparative cellular analysis of motor cortex in human, marmoset and mouse</span>, <em>Nature,</em> 2021.
 				<br/>
 				Hodge, Bakken, et al. <span class="middle-blue">Conserved Cell Types With Divergent Features in Human Versus Mouse Cortex</span>, <em>Nature,</em> 2019.
 				<br/>


### PR DESCRIPTION
I forgot two update the mentioning of the BioRXiv paper with the new Nature title so that should be fixed now as well.
